### PR TITLE
Fix & Feat [Cloud Sync]

### DIFF
--- a/app/utils/cloud/index.ts
+++ b/app/utils/cloud/index.ts
@@ -15,22 +15,19 @@ export const SyncClients = {
 } as const;
 
 type SyncClientConfig = {
-  [K in keyof typeof SyncClients]: (typeof SyncClients)[K] extends (
-    _: infer C,
-  ) => any
-    ? C
-    : never;
+  [K in keyof typeof SyncClients]: Parameters<(typeof SyncClients)[K]>[0];
 };
 
-export type SyncClient = {
+export type SyncClient<T extends ProviderType> = {
   get: (key: string) => Promise<string>;
-  set: (key: string, value: Object | string) => Promise<void>; // Update the parameter type to accept both object and string
+  set: (key: string, value: string | Object) => Promise<void>;
   check: () => Promise<boolean>;
 };
 
-export function createSyncClient<T extends keyof typeof SyncClients>(
+export function createSyncClient<T extends ProviderType>(
   provider: T,
   config: SyncClientConfig[T],
-): SyncClient {
-  return SyncClients[provider](config as any) as any;
+): SyncClient<T> {
+  return SyncClients[provider](config) as SyncClient<T>;
 }
+


### PR DESCRIPTION
[+] fix(sync.ts): import SyncClient from utils/cloud and add type annotations to getClient and syncWebDAV functions
[+] feat(sync.ts): add type annotations to syncGitHubGist function and handle different types of value parameter
[+] fix(index.ts): update SyncClient type definition to accept string or object as value parameter in set function
[+] feat(index.ts): update createSyncClient function to use generic type for provider parameter and return SyncClient with correct type