### PR TITLE
Client App [Restart] [Chat Commands]

### DIFF
--- a/app/command.ts
+++ b/app/command.ts
@@ -1,6 +1,9 @@
 import { useEffect } from "react";
 import { useSearchParams } from "react-router-dom";
 import Locale from "./locales";
+import { getClientConfig } from "@/app/config/client";
+
+const isApp = !!getClientConfig()?.isApp;
 
 type Command = (param: string) => void;
 interface Commands {
@@ -37,6 +40,7 @@ interface ChatCommands {
   newm?: Command;
   next?: Command;
   prev?: Command;
+  restart?: Command;
   clear?: Command;
   del?: Command;
   save?: Command;
@@ -48,6 +52,12 @@ interface ChatCommands {
 export const ChatCommandPrefix = ":";
 
 export function useChatCommand(commands: ChatCommands = {}) {
+  const chatCommands = { ...commands };
+
+  if (!isApp) {
+    delete chatCommands.restart;
+  }
+
   function extract(userInput: string) {
     return (
       userInput.startsWith(ChatCommandPrefix) ? userInput.slice(1) : userInput
@@ -57,7 +67,7 @@ export function useChatCommand(commands: ChatCommands = {}) {
   function search(userInput: string) {
     const input = extract(userInput);
     const desc = Locale.Chat.Commands;
-    return Object.keys(commands)
+    return Object.keys(chatCommands)
       .filter((c) => c.startsWith(input))
       .map((c) => ({
         title: desc[c as keyof ChatCommands],
@@ -67,11 +77,11 @@ export function useChatCommand(commands: ChatCommands = {}) {
 
   function match(userInput: string) {
     const command = extract(userInput);
-    const matched = typeof commands[command] === "function";
+    const matched = typeof chatCommands[command] === "function";
 
     return {
       matched,
-      invoke: () => matched && commands[command]!(userInput),
+      invoke: () => matched && chatCommands[command]!(userInput),
     };
   }
 

--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -677,6 +677,7 @@ function _Chat() {
     newm: () => navigate(Path.NewChat),
     prev: () => chatStore.nextSession(-1),
     next: () => chatStore.nextSession(1),
+    restart: () => window.__TAURI__?.process.relaunch(),
     clear: () =>
       chatStore.updateCurrentSession(
         (session) => (session.clearContextIndex = session.messages.length),

--- a/app/global.d.ts
+++ b/app/global.d.ts
@@ -20,6 +20,9 @@ declare interface Window {
     fs: {
       writeBinaryFile(path: string, data: Uint8Array): Promise<void>;
     };
+    process: {
+      relaunch(): Promise<void>;
+    };
     notification:{
       requestPermission(): Promise<Permission>;
       isPermissionGranted(): Promise<boolean>;

--- a/app/locales/cn.ts
+++ b/app/locales/cn.ts
@@ -66,6 +66,7 @@ const cn = {
       newm: "从面具新建聊天",
       next: "下一个聊天",
       prev: "上一个聊天",
+      restart: "重新启动客户端",
       clear: "清除上下文",
       del: "删除聊天",
       save: "保存当前会话聊天",

--- a/app/locales/en.ts
+++ b/app/locales/en.ts
@@ -68,6 +68,7 @@ const en: LocaleType = {
       newm: "Start a new chat with mask",
       next: "Next Chat",
       prev: "Previous Chat",
+      restart: "Restart a client",
       clear: "Clear Context",
       del: "Delete Chat",
       save: "Save a current session chat",

--- a/app/locales/id.ts
+++ b/app/locales/id.ts
@@ -55,6 +55,7 @@ const id: PartialLocaleType = {
       newm: "Mulai Chat Baru dengan Masks",
       next: "Chat Selanjutnya",
       prev: "Chat Sebelumnya",
+      restart: "Restart klien",
       clear: "Bersihkan Percakapan",
       del: "Hapus Chat",
       save: "Simpan Percakapan Sesi Saat Ini",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -17,7 +17,7 @@ tauri-build = { version = "1.3.0", features = [] }
 [dependencies]
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
-tauri = { version = "1.3.0", features = [ "fs-all", "notification-all", "clipboard-all", "dialog-all", "shell-open", "updater", "window-close", "window-hide", "window-maximize", "window-minimize", "window-set-icon", "window-set-ignore-cursor-events", "window-set-resizable", "window-show", "window-start-dragging", "window-unmaximize", "window-unminimize"] }
+tauri = { version = "1.3.0", features = [ "process-relaunch", "fs-all", "notification-all", "clipboard-all", "dialog-all", "shell-open", "updater", "window-close", "window-hide", "window-maximize", "window-minimize", "window-set-icon", "window-set-ignore-cursor-events", "window-set-resizable", "window-show", "window-start-dragging", "window-unmaximize", "window-unminimize"] }
 tauri-plugin-window-state = { git = "https://github.com/tauri-apps/plugins-workspace", branch = "v1" }
 
 [features]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -50,6 +50,9 @@
       },
       "notification": {
         "all": true
+      },
+      "process": {
+        "relaunch": true
       }
     },
     "bundle": {


### PR DESCRIPTION
Note : This Runtime `Edge`

[+] feat(command.ts): add support for restart command in chat commands
[+] fix(command.ts): remove restart command from chat commands if not running in app environment
[+] feat(chat.tsx): add restart command functionality to restart the client
[+] feat(global.d.ts): add relaunch method to process object in window interface
[+] feat(locales): add translations for restart command in English, Chinese, and Indonesian