### PR TITLE
Feat OpenAI Path [Text Moderation]

### DIFF
--- a/app/components/settings.tsx
+++ b/app/components/settings.tsx
@@ -1386,6 +1386,21 @@ export function Settings() {
               config.update((config) => (config.modelConfig = modelConfig));
             }}
           />
+          <ListItem
+            title={Locale.Settings.TextModeration.Title}
+            subTitle={Locale.Settings.TextModeration.SubTitle}
+          >
+            <input
+              type="checkbox"
+              checked={config.textmoderation}
+              onChange={(e) =>
+                updateConfig(
+                  (config) =>
+                    (config.textmoderation = e.currentTarget.checked),
+                )
+              }
+            ></input>
+          </ListItem>
         </List>
 
         {shouldShowPromptModal && (

--- a/app/locales/cn.ts
+++ b/app/locales/cn.ts
@@ -455,6 +455,10 @@ const cn = {
       Title: "频率惩罚度 (frequency_penalty)",
       SubTitle: "值越大，越有可能降低重复字词",
     },
+    TextModeration: {
+      Title: "文本审核",
+      SubTitle: "通过文本审核来检查内容是否符合 OpenAI 的使用政策。",
+    },
     NumberOfImages: {
       Title: "创建图片数量",
       SubTitle:

--- a/app/locales/en.ts
+++ b/app/locales/en.ts
@@ -462,6 +462,11 @@ const en: LocaleType = {
       SubTitle:
         "A larger value decreasing the likelihood to repeat the same line",
     },
+    TextModeration: {
+      Title: "Text Moderation",
+      SubTitle:
+        "A Text Moderation to check whether content complies with OpenAI's usage policies.",
+    },
     NumberOfImages: {
       Title: "Number Image Create",
       SubTitle:

--- a/app/locales/id.ts
+++ b/app/locales/id.ts
@@ -394,6 +394,10 @@ const id: PartialLocaleType = {
       SubTitle:
         "Semakin tinggi nilai, semakin rendah kemungkinan penggunaan ulang baris yang sama",
     },
+    TextModeration: {
+      Title: "Moderasi Teks",
+      SubTitle: "Moderasi Teks untuk memeriksa apakah konten sesuai dengan kebijakan penggunaan OpenAI.",
+    },
     NumberOfImages: {
       Title: "Buat Jumlah Gambar",
       SubTitle:


### PR DESCRIPTION
[+] feat(openai.ts): add support for text moderation configuration from app config state
[+] feat(settings.tsx): add checkbox for enabling/disabling text moderation in settings
[+] fix(constant.ts): remove unused TextModeration constant
[+] feat(locales): add translations for TextModeration title and subtitle in multiple languages
[+] feat(config.ts): add textmoderation property to DEFAULT_CONFIG and set it to true by default
[+] fix(config.ts): update version to 3.9 and add migration to set textmoderation to true for older versions

Note : This is a cherry pick from the experimental branch that hasn't been merged into the main branch yet.