### PR TITLE
Feat Tauri Shortcut [Pinned App] [Mouse Click] [Desktop App]

### DIFF
--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -724,11 +724,20 @@ function usePinApp() {
         togglePinApp();
       }
     };
+    //Usage : Mouse+5,Mouse+4,Mouse+1(Middle Click)
+    //You need copy paste (e.g., "Mouse+5" paste in settings) instead of typing manually in settings
+    const handleMouseClick = (event: MouseEvent) => {
+      if (event.button === 1 || event.button === 4 || event.button === 5) {
+        togglePinApp();
+      }
+    };
 
     document.addEventListener("keydown", handleKeyPress);
+    document.addEventListener("mousedown", handleMouseClick);
 
     return () => {
       document.removeEventListener("keydown", handleKeyPress);
+      document.removeEventListener("mousedown", handleMouseClick);
     };
   }, [TauriShortcut, togglePinApp]);
 

--- a/app/components/settings.tsx
+++ b/app/components/settings.tsx
@@ -1025,7 +1025,7 @@ export function Settings() {
               <input
                 type="text"
                 value={config.desktopShortcut}
-                placeholder="eg ALT+F4"
+                placeholder="e.g., ALT+F4"
                 onChange={(e) =>
                   config.update((config) => {
                     const shortcut = e.currentTarget.value;

--- a/app/global.d.ts
+++ b/app/global.d.ts
@@ -33,6 +33,7 @@ declare interface Window {
       installUpdate(): Promise<void>;
       onUpdaterEvent(handler: (status: UpdateStatusResult) => void): Promise<UnlistenFn>;
     };
+    // no longer needed now, because tauri app basically it's build own browser
     globalShortcut: {
       isRegistered(shortcut: string): Promise<boolean>;
       register(shortcut: string, handler: ShortcutHandler): Promise<void>;


### PR DESCRIPTION
[+] feat(chat.tsx): add support for pinning the app using mouse middle click or mouse buttons 4 and 5
[+] fix(settings.tsx): update placeholder text for desktopShortcut input field