### PR TITLE
Feat UI/UX Page [Exporter Messages]

### DIFF
--- a/app/components/exporter.tsx
+++ b/app/components/exporter.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @next/next/no-img-element */
-import { ChatMessage, ModelType, useAppConfig, useChatStore } from "../store";
+import { ChatMessage, ModelType, useAccessStore, useAppConfig, useChatStore } from "../store";
 import Locale from "../locales";
 import styles from "./exporter.module.scss";
 import {
@@ -513,6 +513,8 @@ export function ImagePreviewer(props: {
     }
   };
 
+  const accessStore = useAccessStore.getState();
+
   return (
     <div className={styles["image-previewer"]}>
       <PreviewActions
@@ -552,6 +554,9 @@ export function ImagePreviewer(props: {
             </div>
             <div className={styles["chat-info-item"]}>
             {"🤖"} {Locale.Exporter.Model}: {mask.modelConfig.model}
+            </div>
+            <div className={styles["chat-info-item"]}>
+            {"🚀"} {Locale.Exporter.ServiceProvider}: {accessStore.provider}
             </div>
             <div className={styles["chat-info-item"]}>
             {"💭"} {Locale.Exporter.Messages}: {props.messages.length}

--- a/app/locales/cn.ts
+++ b/app/locales/cn.ts
@@ -600,6 +600,7 @@ const cn = {
       Title: "只有清除上下文之后的消息会被展示"
     },  
     Model: "模型",
+    ServiceProvider: "服务提供商",
     Messages: "消息",
     Topic: "主题",
     Time: "时间",

--- a/app/locales/en.ts
+++ b/app/locales/en.ts
@@ -604,6 +604,7 @@ const en: LocaleType = {
       Title: "Only messages after clearing the context will be displayed"
     },  
     Model: "Model",
+    ServiceProvider: "Service Provider",
     Messages: "Messages",
     Topic: "Topic",
     Time: "Date & Time",

--- a/app/locales/id.ts
+++ b/app/locales/id.ts
@@ -531,6 +531,7 @@ const id: PartialLocaleType = {
       Title: "Hanya pesan setelah menghapus konteks yang akan ditampilkan"
     },  
     Model: "Model",
+    ServiceProvider: "Penyedia Layanan",
     Messages: "Pesan",
     Topic: "Topik",
     Time: "Tanggal & Waktu",


### PR DESCRIPTION
[+] feat(exporter.tsx): add support for accessing the provider in ImagePreviewer component
[+] feat(cn.ts): add translation for "ServiceProvider"
[+] feat(en.ts): add translation for "ServiceProvider"
[+] feat(id.ts): add translation for "ServiceProvider"