### PR TITLE
Fix UI/UX Page Chats [Memory Prompt] [Stored Local Storage]

### DIFF
--- a/app/store/chat.ts
+++ b/app/store/chat.ts
@@ -645,7 +645,10 @@ export const useChatStore = createPersistStore(
               whitelist: true,
               onFinish(message) {
                 console.log("[Memory] ", message);
-                session.lastSummarizeIndex = lastSummarizeIndex;
+                get().updateCurrentSession((session) => {
+                  session.lastSummarizeIndex = lastSummarizeIndex;
+                  session.memoryPrompt = message; // Update the memory prompt for stored it in local storage
+                });
                 showToast(
                   Locale.Chat.Commands.UI.SummarizeSuccess,
                 );


### PR DESCRIPTION
- [+] fix(chat.ts): update lastSummarizeIndex and memoryPrompt in useChatStore's onFinish function


Issue known : [Bug] Memory Prompt not stored properly in top 1 of chat list #3368