### PR TITLE
Add useMaxTokens option to ChatGPT LLMApi

### DIFF
--- a/app/client/platforms/openai.ts
+++ b/app/client/platforms/openai.ts
@@ -87,7 +87,8 @@ export class ChatGPTApi implements LLMApi {
   private getNewStuff(
     model: string,
     max_tokens?: number,
-    system_fingerprint?: string
+    system_fingerprint?: string,
+    useMaxTokens: boolean = true,
   ): {
     max_tokens?: number;
     system_fingerprint?: string;
@@ -105,7 +106,7 @@ export class ChatGPTApi implements LLMApi {
 
     if (isNewModel) {
       return {
-        max_tokens: max_tokens !== undefined ? max_tokens : modelConfig.max_tokens,
+        max_tokens: useMaxTokens ? (max_tokens !== undefined ? max_tokens : modelConfig.max_tokens) : undefined,
         system_fingerprint:
           system_fingerprint !== undefined
             ? system_fingerprint
@@ -251,7 +252,8 @@ export class ChatGPTApi implements LLMApi {
     const { max_tokens, system_fingerprint } = this.getNewStuff(
       modelConfig.model,
       modelConfig.max_tokens,
-      modelConfig.system_fingerprint
+      modelConfig.system_fingerprint,
+      modelConfig.useMaxTokens,
     );
 
     /**
@@ -273,7 +275,7 @@ export class ChatGPTApi implements LLMApi {
         top_p: modelConfig.top_p,
         // beta test for new model's since it consumed much tokens
         // max is 4096
-        ...{ max_tokens }, // Spread the max_tokens value
+        ...(max_tokens !== undefined ? { max_tokens } : {}), // Spread the max_tokens value if defined
         // not yet ready
         //...{ system_fingerprint }, // Spread the system_fingerprint value
       },

--- a/app/client/platforms/openai.ts
+++ b/app/client/platforms/openai.ts
@@ -80,6 +80,7 @@ export class ChatGPTApi implements LLMApi {
    * @param model - The model to retrieve information for.
    * @param max_tokens - The maximum number of tokens.
    * @param system_fingerprint - The system fingerprint.
+   * @param useMaxTokens - Whether to use the maximum number of max tokens.
    * @returns An object containing information about the new stuff.
    *
    * @author H0llyW00dzZ

--- a/app/components/model-config.tsx
+++ b/app/components/model-config.tsx
@@ -116,6 +116,43 @@ export function ModelConfigList(props: {
       {!isDalleModel && (
         <>
           <ListItem
+            title={Locale.Settings.UseMaxTokens.Title}
+            subTitle={Locale.Settings.UseMaxTokens.SubTitle}
+          >
+            <input
+              type="checkbox"
+              checked={props.modelConfig.useMaxTokens}
+              onChange={(e) =>
+                props.updateConfig(
+                  (config) => (config.useMaxTokens = e.currentTarget.checked)
+                )
+              }
+            ></input>
+          </ListItem>
+          {props.modelConfig.useMaxTokens && (
+            <>
+              <ListItem
+                title={Locale.Settings.MaxTokens.Title}
+                subTitle={Locale.Settings.MaxTokens.SubTitle}
+              >
+                <input
+                  type="number"
+                  min={1024}
+                  max={512000}
+                  value={props.modelConfig.max_tokens}
+                  onChange={(e) =>
+                    props.updateConfig(
+                      (config) =>
+                        (config.max_tokens = ModalConfigValidator.max_tokens(
+                          e.currentTarget.valueAsNumber
+                        ))
+                    )
+                  }
+                ></input>
+              </ListItem>
+            </>
+          )}
+          <ListItem
             title={Locale.Settings.Temperature.Title}
             subTitle={Locale.Settings.Temperature.SubTitle}
           >
@@ -152,25 +189,6 @@ export function ModelConfigList(props: {
                 );
               }}
             ></InputRange>
-          </ListItem>
-          <ListItem
-            title={Locale.Settings.MaxTokens.Title}
-            subTitle={Locale.Settings.MaxTokens.SubTitle}
-          >
-            <input
-              type="number"
-              min={1024}
-              max={512000}
-              value={props.modelConfig.max_tokens}
-              onChange={(e) =>
-                props.updateConfig(
-                  (config) =>
-                  (config.max_tokens = ModalConfigValidator.max_tokens(
-                    e.currentTarget.valueAsNumber,
-                  )),
-                )
-              }
-            ></input>
           </ListItem>
           <ListItem
             title={Locale.Settings.PresencePenalty.Title}

--- a/app/locales/cn.ts
+++ b/app/locales/cn.ts
@@ -467,6 +467,10 @@ const cn = {
       Title: "单次回复限制 (max_tokens)",
       SubTitle: "单次交互所用的最大 Token 数",
     },
+    UseMaxTokens: {
+      Title: "使用最大标记数",
+      SubTitle: "是否使用最大标记数。",
+    },
     PresencePenalty: {
       Title: "话题新鲜度 (presence_penalty)",
       SubTitle: "值越大，越有可能扩展到新话题",

--- a/app/locales/en.ts
+++ b/app/locales/en.ts
@@ -472,6 +472,10 @@ const en: LocaleType = {
       Title: "Max Tokens",
       SubTitle: "Maximum length of input tokens and generated tokens",
     },
+    UseMaxTokens: {
+      Title: "Use Max Tokens",
+      SubTitle: "Whether to use the maximum number of max tokens.",
+    },
     PresencePenalty: {
       Title: "Presence Penalty",
       SubTitle:

--- a/app/locales/id.ts
+++ b/app/locales/id.ts
@@ -405,6 +405,10 @@ const id: PartialLocaleType = {
       Title: "Token Maksimum",
       SubTitle: "Panjang maksimum token input dan output",
     },
+    UseMaxTokens: {
+      Title: "Gunakan Jumlah Token Maksimum",
+      SubTitle: "Apakah akan menggunakan jumlah maksimum token.",
+    },
     PresencePenalty: {
       Title: "Penalti Kehadiran",
       SubTitle: "Semakin tinggi nilai, semakin mungkin topik baru muncul",

--- a/app/store/config.ts
+++ b/app/store/config.ts
@@ -79,6 +79,7 @@ export const DEFAULT_CONFIG = {
     style: "vivid", // Only DALL·E-3 for DALL·E-2 not not really needed
     system_fingerprint: "",
     sendMemory: true,
+    useMaxTokens: false,
     historyMessageCount: 4,
     compressMessageLengthThreshold: 1000,
     enableInjectSystemPrompts: true,
@@ -266,6 +267,12 @@ export const useAppConfig = createPersistStore(
 
       if (version < 4.3) {
         state.speed_animation = 60;
+      }
+
+      // control useMaxTokens for latest models gpt-4-1106-preview, default is false
+
+      if (version < 4.4) {
+        state.modelConfig.useMaxTokens = false;
       }
 
       return state as any;


### PR DESCRIPTION
- [+] feat(openai.ts): add support for `useMaxTokens` parameter in `getNewStuff` method
- [+] fix(openai.ts): update `max_tokens` value in `getNewStuff` method based on `useMaxTokens` parameter
- [+] feat(config.ts): add `useMaxTokens` property to `DEFAULT_CONFIG` and set it to false
- [+] feat(config.ts): set `useMaxTokens` to false for models with version less than 4.4 in `useAppConfig`