### PR TITLE
Revert "Fix [TypesScript] [LLM Api] Chaining Model"

### DIFF
--- a/app/client/api.ts
+++ b/app/client/api.ts
@@ -47,7 +47,7 @@ export interface LLMUsage {
 export interface LLMModel {
   name: string;
   available: boolean;
-  provider?: LLMModelProvider;
+  provider: LLMModelProvider;
 }
 
 export interface LLMModelProvider {


### PR DESCRIPTION
This reverts commit 445c070cc6d021ddc426869b115c4623c02ca451.

Reason: It's suddenly stopped lmao