### PR TITLE
Bump Version for Docker & Tauri [Offline Build]

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -9,7 +9,7 @@
   },
   "package": {
     "productName": "NextChat",
-    "version": "2.10.2"
+    "version": "2.10.3"
   },
   "tauri": {
     "allowlist": {


### PR DESCRIPTION
- [+] chore(tauri.conf.json): bump version from 2.10.2 to 2.10.3

Note: This a better way instead of using stupid CI/CD because rust unlike go about compiler