### PR TITLE
Fix [UI/UX] [Front End] [Chat] doSubmit

### DIFF
--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -926,7 +926,6 @@ function _Chat() {
     }
     setIsLoading(true);
     chatStore.onUserInput(userInput).then(() => setIsLoading(false));
-    localStorage.setItem(LAST_INPUT_KEY, userInput);
     setUserInput("");
     setPromptHints([]);
     if (!isMobileScreen) inputRef.current?.focus();


### PR DESCRIPTION
- [+] fix(chat.tsx): remove localStorage.setItem for LAST_INPUT_KEY in _Chat function

Note: By removing the localStorage.setItem function, we're minimizing the use of local storage in the browser. This is different from the original head repository. Essentially, only unfinished inputs will be affected, and this occurs only when they are literally incomplete.